### PR TITLE
Use a build step within the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
-FROM debian:stable-slim
+FROM golang:1.16-stretch as build
+ARG GOARCH="amd64"
+COPY . /build_dir
+WORKDIR /build_dir
+RUN make clean && make build
 
+FROM debian:stable-slim
 RUN apt-get update && apt-get -y install ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
-COPY smtprelay /usr/local/bin/smtprelay
+COPY --from=build /build_dir/smtprelay /usr/local/bin/smtprelay
 # users need to mount config file at /usr/local/smtprelay.ini
 ENTRYPOINT ["/usr/local/bin/smtprelay"]


### PR DESCRIPTION
Otherwise it'll build a binary that is local to the host OS and thus
make it inconsistent and prone to errors