### PR TITLE
Adding golangci-lint check to CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,13 +13,28 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-
-    - uses: actions/setup-go@v4
-      with:
-        go-version: '1.21'
-    - uses: actions/checkout@v4
-    - name: Get dependencies
-      run: |
-        go mod tidy
-    - name: Build
-      run: go build -v .
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - name: Get dependencies
+        run: |
+          go mod tidy
+      - name: Build
+        run: go build -v .
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          args: --max-same-issues=0 --max-issues-per-linter=0 --verbose
+          only-new-issues: true
+          skip-cache: true
+          install-mode: binary

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,106 @@
+linters-settings:
+  govet:
+    check-shadowing: true
+    enable-all: true
+  gocyclo:
+    min-complexity: 10
+  gocritic:
+    disabled-checks:
+      - commentFormatting
+  dupl:
+    threshold: 100
+  goconst:
+    min-len: 3
+    min-occurrences: 6
+    ignore-tests: true
+  lll:
+    line-length: 140
+  nolintlint:
+    allow-unused: false # report any unused nolint directives
+    require-explanation: false # don't require an explanation for nolint directives
+    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+  errcheck:
+    exclude-functions:
+      - io/ioutil.WriteFile
+      - io/ioutil.ReadFile
+      - io.Copy
+  gocognit:
+    min-complexity: 31
+  gomoddirectives:
+    replace-allow-list: []
+  depguard:
+    rules:
+      main:
+        deny:
+          - pkg: github.com/pkg/errors
+            desc: 'use `fmt.Errorf` instead, or the stdlib `errors` package'
+
+linters:
+  disable-all: true
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - containedctx
+    - contextcheck
+    - depguard
+    - dupl
+    - dupword
+    - durationcheck
+    # - errcheck
+    - errname
+    # - errorlint
+    - exportloopref
+    # - gocognit
+    - goconst
+    # - gocritic
+    # - gofmt
+    - goheader
+    # - goimports
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    # - gosec
+    # - govet
+    - ineffassign
+    - loggercheck
+    - makezero
+    - misspell
+    - nakedret
+    # - nestif
+    - noctx
+    - nolintlint
+    - nosprintfhostport
+    - prealloc
+    - predeclared
+    # - promlinter
+    - reassign
+    # - revive
+    - rowserrcheck
+    - sqlclosecheck
+    - tenv
+    - testableexamples
+    - thelper
+    - tparallel
+    - typecheck
+    # - unconvert
+    - unparam
+    - unused
+    - usestdlibvars
+    # these linters may need to be ignored because they can be slow
+    # - gosimple
+    # - staticcheck
+    # - stylecheck
+
+# issues:
+#   # Excluding configuration per-path, per-linter, per-text and per-source
+#   exclude-rules:
+#     - path: _test\.go
+#       linters:
+#         - govet
+#         - dupl
+
+# run:
+#   concurrency: 8
+#   timeout: 10m

--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,7 @@ docker-push:  docker
 	docker push $(DOCKER_TAG)
 	docker tag $(DOCKER_TAG) $(DOCKER_TAG):$(BUILD_VERSION)
 	docker push $(DOCKER_TAG):$(BUILD_VERSION)
+
+.PHONY: lint
+lint:
+	@golangci-lint run --max-same-issues=0 --max-issues-per-linter=0 -v


### PR DESCRIPTION
Adding a lint step to CI. Turning off all failing linters for now - will turn them on progressively in future PRs.