### PR TITLE
make/CI improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
+/bin/
 smtprelay
 smtprelay.log
 *.ini
 !smtprelay.ini
 .idea
-cover.out
+*.out

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apk add --no-cache --upgrade \
         libssl3>=3.1.4-r1
 
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=build /go/src/github.com/grafana/smtprelay/smtprelay /usr/local/bin/smtprelay
+COPY --from=build /go/src/github.com/grafana/smtprelay/bin/smtprelay /usr/local/bin/smtprelay
 
 ARG GIT_REVISION
 

--- a/config.mk
+++ b/config.mk
@@ -1,4 +1,0 @@
-# This file is included from the main makefile. Anything that is
-# specific to this module should go in this file.
-
-DOCKER_TAG = grafana/smtprelay


### PR DESCRIPTION
Some small build/dev/CI updates:
- moving the binary to `bin/`
- ignoring `*.out` rather than `cover.out` (which wasn't written - it was `c.out`)
- ditching `config.mk` - adds unnecessary complexity
