### PR TITLE
Enable profiling with pprof

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -97,6 +98,12 @@ func handleMetrics(ctx context.Context, addr string, registry prometheus.Registe
 			EnableOpenMetrics: true,
 		}),
 	))
+
+	router.HandleFunc("/debug/pprof/", pprof.Index)
+	router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	router.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	router.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
 	srv := &http.Server{
 		// 5s timeout for header reads to avoid Slowloris attacks (https://thetooth.io/blog/slowloris-attack/)


### PR DESCRIPTION
Expose the pprof endpoint on the metrics HTTP server