### PR TITLE
remove unnecessary upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,6 @@ RUN bin/smtprelay --version
 
 FROM alpine:3.19 AS runtime
 
-RUN apk add --no-cache --upgrade \
-        libcrypto3>=3.1.4-r1 \
-        libssl3>=3.1.4-r1
-
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /go/src/github.com/grafana/smtprelay/bin/smtprelay /usr/local/bin/smtprelay
 


### PR DESCRIPTION
Alpine 3.19 doesn't need this