### PR TITLE
Support context propagation in smtpd

### DIFF
--- a/config.go
+++ b/config.go
@@ -75,7 +75,7 @@ func loadConfig() (*config, error) {
 
 	setupLogger(cfg.logFormat, cfg.logLevel)
 
-	logger := slog.Default().With(slog.String("component", "config"))
+	logger := slog.With(slog.String("component", "config"))
 
 	// if remotePass is not set, try reading it from env var
 	if cfg.remotePass == "" {

--- a/internal/smtpd/protocol_test.go
+++ b/internal/smtpd/protocol_test.go
@@ -3,7 +3,6 @@ package smtpd
 import "testing"
 
 func TestParseLine(t *testing.T) {
-
 	cmd := parseLine("HELO hostname")
 	if cmd.action != "HELO" {
 		t.Fatalf("unexpected action: %s", cmd.action)
@@ -58,7 +57,6 @@ func TestParseLine(t *testing.T) {
 }
 
 func TestParseLineMailformedMAILFROM(t *testing.T) {
-
 	cmd := parseLine("MAIL FROM: <test@example.org>")
 	if cmd.action != "MAIL" {
 		t.Fatalf("unexpected action: %s", cmd.action)
@@ -79,5 +77,4 @@ func TestParseLineMailformedMAILFROM(t *testing.T) {
 	if cmd.params[1] != "<test@example.org>" {
 		t.Fatalf("unexpected value for param 1: %v", cmd.params[1])
 	}
-
 }

--- a/relay_test.go
+++ b/relay_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"log/slog"
 	"strings"
@@ -66,13 +67,14 @@ func Test_RecepientsCheck(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
 	r := &relay{}
 	for _, tt := range tc {
 		t.Run(tt.name, func(t *testing.T) {
 			checker := r.recipientChecker(tt.allowed, tt.denied)
 
 			for _, e := range tt.emails {
-				if err := checker(smtpd.Peer{}, e); err != nil {
+				if err := checker(ctx, smtpd.Peer{}, e); err != nil {
 					if !errors.Is(err, tt.expected) {
 						t.Errorf("got %d, want %d for the email %s", err, tt.expected, e)
 					}


### PR DESCRIPTION
Adds context propagation through the smtpd Server, and handlers. Alone, it helps with cancel propagation, but this will also serve #57 for trace propagation.

This was mainly inspired with how things work in `net/http` (hence the addition of the `ConnContext` function), but because we're not tied to any kind of API promises, I opted to change the `Serve` signature rather than adding a `BaseContext` function.

Because `log/slog` can make use of context in log statements, this also makes a few log-related modifications.

Also there are some minor refactorings (whitespace removal, etc) that are mainly just there to make things easier to read.