### PR TITLE
Error refactoring

### DIFF
--- a/internal/smtpd/errors.go
+++ b/internal/smtpd/errors.go
@@ -1,0 +1,19 @@
+package smtpd
+
+import "net/textproto"
+
+var (
+	ErrIPDenied              = &textproto.Error{Code: 421, Msg: "Denied - IP out of allowed network range"}
+	ErrRecipientDenied       = &textproto.Error{Code: 451, Msg: "Denied recipient address"}
+	ErrRecipientInvalid      = &textproto.Error{Code: 451, Msg: "Invalid recipient address"}
+	ErrSenderDenied          = &textproto.Error{Code: 451, Msg: "sender address not allowed"}
+	ErrUnsupportedAuthMethod = &textproto.Error{Code: 530, Msg: "Authentication method not supported"}
+	ErrAuthInvalid           = &textproto.Error{Code: 535, Msg: "Authentication credentials invalid"}
+	ErrForwardingFailed      = &textproto.Error{Code: 554, Msg: "Forwarding failed"}
+
+	//TODO: make sure these each make sense - there's overlap
+	Err502Denied   = &textproto.Error{Code: 502, Msg: "Denied"}
+	Err550Denied   = &textproto.Error{Code: 550, Msg: "Denied"}
+	Err550Rejected = &textproto.Error{Code: 550, Msg: "Rejected"}
+	Err552Denied   = &textproto.Error{Code: 552, Msg: "Denied"}
+)

--- a/internal/smtpd/errors.go
+++ b/internal/smtpd/errors.go
@@ -3,17 +3,33 @@ package smtpd
 import "net/textproto"
 
 var (
-	ErrIPDenied              = &textproto.Error{Code: 421, Msg: "Denied - IP out of allowed network range"}
-	ErrRecipientDenied       = &textproto.Error{Code: 451, Msg: "Denied recipient address"}
-	ErrRecipientInvalid      = &textproto.Error{Code: 451, Msg: "Invalid recipient address"}
-	ErrSenderDenied          = &textproto.Error{Code: 451, Msg: "sender address not allowed"}
-	ErrUnsupportedAuthMethod = &textproto.Error{Code: 530, Msg: "Authentication method not supported"}
-	ErrAuthInvalid           = &textproto.Error{Code: 535, Msg: "Authentication credentials invalid"}
-	ErrForwardingFailed      = &textproto.Error{Code: 554, Msg: "Forwarding failed"}
+	ErrBusy              = &textproto.Error{Code: 421, Msg: "Too busy. Try again later."}
+	ErrIPDenied          = &textproto.Error{Code: 421, Msg: "Denied - IP out of allowed network range"}
+	ErrRecipientDenied   = &textproto.Error{Code: 451, Msg: "Denied recipient address"}
+	ErrRecipientInvalid  = &textproto.Error{Code: 451, Msg: "Invalid recipient address"}
+	ErrSenderDenied      = &textproto.Error{Code: 451, Msg: "sender address not allowed"}
+	ErrTooManyRecipients = &textproto.Error{Code: 452, Msg: "Too many recipients"}
 
-	//TODO: make sure these each make sense - there's overlap
-	Err502Denied   = &textproto.Error{Code: 502, Msg: "Denied"}
-	Err550Denied   = &textproto.Error{Code: 550, Msg: "Denied"}
-	Err550Rejected = &textproto.Error{Code: 550, Msg: "Rejected"}
-	Err552Denied   = &textproto.Error{Code: 552, Msg: "Denied"}
+	ErrLineTooLong           = &textproto.Error{Code: 500, Msg: "Line too long"}
+	ErrDuplicateMAIL         = &textproto.Error{Code: 502, Msg: "Duplicate MAIL"}
+	ErrDuplicateSTARTTLS     = &textproto.Error{Code: 502, Msg: "Already running in TLS"}
+	ErrInvalidSyntax         = &textproto.Error{Code: 502, Msg: "Invalid syntax."}
+	ErrMalformedAuth         = &textproto.Error{Code: 502, Msg: "Couldn't decode your credentials"}
+	ErrMalformedCommand      = &textproto.Error{Code: 502, Msg: "Couldn't decode the command"}
+	ErrMalformedEmail        = &textproto.Error{Code: 502, Msg: "Malformed email address"} // TODO: should this be a 502 or 451?
+	ErrMissingParam          = &textproto.Error{Code: 502, Msg: "Missing parameter"}
+	ErrNoHELO                = &textproto.Error{Code: 502, Msg: "Please introduce yourself first."}
+	ErrNoMAIL                = &textproto.Error{Code: 502, Msg: "Missing MAIL FROM command."}
+	ErrNoRCPT                = &textproto.Error{Code: 502, Msg: "Missing RCPT TO command."}
+	ErrNoSTARTTLS            = &textproto.Error{Code: 502, Msg: "Please turn on TLS by issuing a STARTTLS command."}
+	ErrTLSNotSupported       = &textproto.Error{Code: 502, Msg: "TLS not supported"}
+	ErrUnknownAuth           = &textproto.Error{Code: 502, Msg: "Unknown authentication mechanism"}
+	ErrUnsupportedCommand    = &textproto.Error{Code: 502, Msg: "Unsupported command"}
+	ErrUnsupportedConn       = &textproto.Error{Code: 502, Msg: "Unsupported network connection"}
+	ErrUnsupportedAuthMethod = &textproto.Error{Code: 530, Msg: "Authentication method not supported"}
+	ErrAuthRequired          = &textproto.Error{Code: 530, Msg: "Authentication required."}
+	ErrAuthInvalid           = &textproto.Error{Code: 535, Msg: "Authentication credentials invalid"}
+	ErrBadHandshake          = &textproto.Error{Code: 550, Msg: "Handshake error"}
+	ErrTooBig                = &textproto.Error{Code: 552, Msg: "Message exceeded maximum size"}
+	ErrForwardingFailed      = &textproto.Error{Code: 554, Msg: "Forwarding failed"}
 )

--- a/internal/smtpd/smtpd.go
+++ b/internal/smtpd/smtpd.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/textproto"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -95,15 +96,6 @@ type Peer struct {
 	Protocol   Protocol             // Protocol used, SMTP or ESMTP
 	ServerName string               // A copy of Server.Hostname
 }
-
-// Error represents an Error reported in the SMTP session.
-type Error struct {
-	Message string // The error message
-	Code    int    // The integer error code
-}
-
-// Error returns a string representation of the SMTP error
-func (e Error) Error() string { return fmt.Sprintf("%d %s", e.Code, e.Message) }
 
 // ErrServerClosed is returned by the Server's Serve and ListenAndServe,
 // methods after a call to Shutdown.
@@ -429,9 +421,9 @@ func (session *session) flush() {
 }
 
 func (session *session) error(err error) {
-	var smtpdError Error
+	var smtpdError *textproto.Error
 	if errors.As(err, &smtpdError) {
-		session.reply(smtpdError.Code, smtpdError.Message)
+		session.reply(smtpdError.Code, smtpdError.Msg)
 	} else {
 		session.reply(502, fmt.Sprintf("%s", err))
 	}

--- a/internal/smtpd/smtpd_test.go
+++ b/internal/smtpd/smtpd_test.go
@@ -328,7 +328,7 @@ func TestSTARTTLS(t *testing.T) {
 func TestAuthRejection(t *testing.T) {
 	addr, closer := runsslserver(t, &smtpd.Server{
 		Authenticator: func(ctx context.Context, peer smtpd.Peer, username, password string) error {
-			return &textproto.Error{Code: 550, Msg: "Denied"}
+			return smtpd.Err550Denied
 		},
 		ForceTLS:       true,
 		ProtocolLogger: log.New(os.Stdout, "log: ", log.Lshortfile),
@@ -365,7 +365,7 @@ func TestAuthNotSupported(t *testing.T) {
 func TestAuthBypass(t *testing.T) {
 	addr, closer := runsslserver(t, &smtpd.Server{
 		Authenticator: func(ctx context.Context, peer smtpd.Peer, username, password string) error {
-			return &textproto.Error{Code: 550, Msg: "Denied"}
+			return smtpd.Err550Denied
 		},
 		ForceTLS:       true,
 		ProtocolLogger: log.New(os.Stdout, "log: ", log.Lshortfile),
@@ -385,7 +385,7 @@ func TestAuthBypass(t *testing.T) {
 func TestConnectionCheck(t *testing.T) {
 	addr, closer := runserver(t, &smtpd.Server{
 		ConnectionChecker: func(ctx context.Context, peer smtpd.Peer) error {
-			return &textproto.Error{Code: 552, Msg: "Denied"}
+			return smtpd.Err552Denied
 		},
 		ProtocolLogger: log.New(os.Stdout, "log: ", log.Lshortfile),
 	})
@@ -412,7 +412,7 @@ func TestHELOCheck(t *testing.T) {
 	addr, closer := runserver(t, &smtpd.Server{
 		HeloChecker: func(ctx context.Context, peer smtpd.Peer, name string) error {
 			require.Equal(t, "foobar.local", name)
-			return &textproto.Error{Code: 552, Msg: "Denied"}
+			return smtpd.Err552Denied
 		},
 		ProtocolLogger: log.New(os.Stdout, "log: ", log.Lshortfile),
 	})
@@ -429,7 +429,7 @@ func TestHELOCheck(t *testing.T) {
 func TestSenderCheck(t *testing.T) {
 	addr, closer := runserver(t, &smtpd.Server{
 		SenderChecker: func(ctx context.Context, peer smtpd.Peer, addr string) error {
-			return &textproto.Error{Code: 552, Msg: "Denied"}
+			return smtpd.Err552Denied
 		},
 		ProtocolLogger: log.New(os.Stdout, "log: ", log.Lshortfile),
 	})
@@ -445,7 +445,7 @@ func TestSenderCheck(t *testing.T) {
 func TestRecipientCheck(t *testing.T) {
 	addr, closer := runserver(t, &smtpd.Server{
 		RecipientChecker: func(ctx context.Context, peer smtpd.Peer, addr string) error {
-			return &textproto.Error{Code: 552, Msg: "Denied"}
+			return smtpd.Err552Denied
 		},
 		ProtocolLogger: log.New(os.Stdout, "log: ", log.Lshortfile),
 	})
@@ -530,7 +530,7 @@ func TestHandler(t *testing.T) {
 func TestRejectHandler(t *testing.T) {
 	addr, closer := runserver(t, &smtpd.Server{
 		Handler: func(ctx context.Context, peer smtpd.Peer, env smtpd.Envelope) error {
-			return &textproto.Error{Code: 550, Msg: "Rejected"}
+			return smtpd.Err550Rejected
 		},
 		ProtocolLogger: log.New(os.Stdout, "log: ", log.Lshortfile),
 	})
@@ -1050,7 +1050,7 @@ func TestMalformedMAILFROM(t *testing.T) {
 	addr, closer := runserver(t, &smtpd.Server{
 		SenderChecker: func(ctx context.Context, peer smtpd.Peer, addr string) error {
 			if addr != "test@example.org" {
-				return &textproto.Error{Code: 502, Msg: "Denied"}
+				return smtpd.Err502Denied
 			}
 			return nil
 		},

--- a/internal/smtpd/smtpd_test.go
+++ b/internal/smtpd/smtpd_test.go
@@ -328,7 +328,7 @@ func TestSTARTTLS(t *testing.T) {
 func TestAuthRejection(t *testing.T) {
 	addr, closer := runsslserver(t, &smtpd.Server{
 		Authenticator: func(ctx context.Context, peer smtpd.Peer, username, password string) error {
-			return smtpd.Err550Denied
+			return smtpd.ErrAuthInvalid
 		},
 		ForceTLS:       true,
 		ProtocolLogger: log.New(os.Stdout, "log: ", log.Lshortfile),
@@ -365,7 +365,7 @@ func TestAuthNotSupported(t *testing.T) {
 func TestAuthBypass(t *testing.T) {
 	addr, closer := runsslserver(t, &smtpd.Server{
 		Authenticator: func(ctx context.Context, peer smtpd.Peer, username, password string) error {
-			return smtpd.Err550Denied
+			return smtpd.ErrAuthInvalid
 		},
 		ForceTLS:       true,
 		ProtocolLogger: log.New(os.Stdout, "log: ", log.Lshortfile),
@@ -385,7 +385,7 @@ func TestAuthBypass(t *testing.T) {
 func TestConnectionCheck(t *testing.T) {
 	addr, closer := runserver(t, &smtpd.Server{
 		ConnectionChecker: func(ctx context.Context, peer smtpd.Peer) error {
-			return smtpd.Err552Denied
+			return smtpd.ErrIPDenied
 		},
 		ProtocolLogger: log.New(os.Stdout, "log: ", log.Lshortfile),
 	})
@@ -412,7 +412,7 @@ func TestHELOCheck(t *testing.T) {
 	addr, closer := runserver(t, &smtpd.Server{
 		HeloChecker: func(ctx context.Context, peer smtpd.Peer, name string) error {
 			require.Equal(t, "foobar.local", name)
-			return smtpd.Err552Denied
+			return smtpd.ErrUnsupportedCommand
 		},
 		ProtocolLogger: log.New(os.Stdout, "log: ", log.Lshortfile),
 	})
@@ -429,7 +429,7 @@ func TestHELOCheck(t *testing.T) {
 func TestSenderCheck(t *testing.T) {
 	addr, closer := runserver(t, &smtpd.Server{
 		SenderChecker: func(ctx context.Context, peer smtpd.Peer, addr string) error {
-			return smtpd.Err552Denied
+			return smtpd.ErrSenderDenied
 		},
 		ProtocolLogger: log.New(os.Stdout, "log: ", log.Lshortfile),
 	})
@@ -445,7 +445,7 @@ func TestSenderCheck(t *testing.T) {
 func TestRecipientCheck(t *testing.T) {
 	addr, closer := runserver(t, &smtpd.Server{
 		RecipientChecker: func(ctx context.Context, peer smtpd.Peer, addr string) error {
-			return smtpd.Err552Denied
+			return smtpd.ErrRecipientDenied
 		},
 		ProtocolLogger: log.New(os.Stdout, "log: ", log.Lshortfile),
 	})
@@ -530,7 +530,7 @@ func TestHandler(t *testing.T) {
 func TestRejectHandler(t *testing.T) {
 	addr, closer := runserver(t, &smtpd.Server{
 		Handler: func(ctx context.Context, peer smtpd.Peer, env smtpd.Envelope) error {
-			return smtpd.Err550Rejected
+			return smtpd.ErrTooBig
 		},
 		ProtocolLogger: log.New(os.Stdout, "log: ", log.Lshortfile),
 	})
@@ -1050,7 +1050,7 @@ func TestMalformedMAILFROM(t *testing.T) {
 	addr, closer := runserver(t, &smtpd.Server{
 		SenderChecker: func(ctx context.Context, peer smtpd.Peer, addr string) error {
 			if addr != "test@example.org" {
-				return smtpd.Err502Denied
+				return smtpd.ErrRecipientDenied
 			}
 			return nil
 		},

--- a/internal/smtpd/smtpd_test.go
+++ b/internal/smtpd/smtpd_test.go
@@ -328,7 +328,7 @@ func TestSTARTTLS(t *testing.T) {
 func TestAuthRejection(t *testing.T) {
 	addr, closer := runsslserver(t, &smtpd.Server{
 		Authenticator: func(ctx context.Context, peer smtpd.Peer, username, password string) error {
-			return smtpd.Error{Code: 550, Message: "Denied"}
+			return &textproto.Error{Code: 550, Msg: "Denied"}
 		},
 		ForceTLS:       true,
 		ProtocolLogger: log.New(os.Stdout, "log: ", log.Lshortfile),
@@ -365,7 +365,7 @@ func TestAuthNotSupported(t *testing.T) {
 func TestAuthBypass(t *testing.T) {
 	addr, closer := runsslserver(t, &smtpd.Server{
 		Authenticator: func(ctx context.Context, peer smtpd.Peer, username, password string) error {
-			return smtpd.Error{Code: 550, Message: "Denied"}
+			return &textproto.Error{Code: 550, Msg: "Denied"}
 		},
 		ForceTLS:       true,
 		ProtocolLogger: log.New(os.Stdout, "log: ", log.Lshortfile),
@@ -385,7 +385,7 @@ func TestAuthBypass(t *testing.T) {
 func TestConnectionCheck(t *testing.T) {
 	addr, closer := runserver(t, &smtpd.Server{
 		ConnectionChecker: func(ctx context.Context, peer smtpd.Peer) error {
-			return smtpd.Error{Code: 552, Message: "Denied"}
+			return &textproto.Error{Code: 552, Msg: "Denied"}
 		},
 		ProtocolLogger: log.New(os.Stdout, "log: ", log.Lshortfile),
 	})
@@ -412,7 +412,7 @@ func TestHELOCheck(t *testing.T) {
 	addr, closer := runserver(t, &smtpd.Server{
 		HeloChecker: func(ctx context.Context, peer smtpd.Peer, name string) error {
 			require.Equal(t, "foobar.local", name)
-			return smtpd.Error{Code: 552, Message: "Denied"}
+			return &textproto.Error{Code: 552, Msg: "Denied"}
 		},
 		ProtocolLogger: log.New(os.Stdout, "log: ", log.Lshortfile),
 	})
@@ -429,7 +429,7 @@ func TestHELOCheck(t *testing.T) {
 func TestSenderCheck(t *testing.T) {
 	addr, closer := runserver(t, &smtpd.Server{
 		SenderChecker: func(ctx context.Context, peer smtpd.Peer, addr string) error {
-			return smtpd.Error{Code: 552, Message: "Denied"}
+			return &textproto.Error{Code: 552, Msg: "Denied"}
 		},
 		ProtocolLogger: log.New(os.Stdout, "log: ", log.Lshortfile),
 	})
@@ -445,7 +445,7 @@ func TestSenderCheck(t *testing.T) {
 func TestRecipientCheck(t *testing.T) {
 	addr, closer := runserver(t, &smtpd.Server{
 		RecipientChecker: func(ctx context.Context, peer smtpd.Peer, addr string) error {
-			return smtpd.Error{Code: 552, Message: "Denied"}
+			return &textproto.Error{Code: 552, Msg: "Denied"}
 		},
 		ProtocolLogger: log.New(os.Stdout, "log: ", log.Lshortfile),
 	})
@@ -530,7 +530,7 @@ func TestHandler(t *testing.T) {
 func TestRejectHandler(t *testing.T) {
 	addr, closer := runserver(t, &smtpd.Server{
 		Handler: func(ctx context.Context, peer smtpd.Peer, env smtpd.Envelope) error {
-			return smtpd.Error{Code: 550, Message: "Rejected"}
+			return &textproto.Error{Code: 550, Msg: "Rejected"}
 		},
 		ProtocolLogger: log.New(os.Stdout, "log: ", log.Lshortfile),
 	})
@@ -1050,7 +1050,7 @@ func TestMalformedMAILFROM(t *testing.T) {
 	addr, closer := runserver(t, &smtpd.Server{
 		SenderChecker: func(ctx context.Context, peer smtpd.Peer, addr string) error {
 			if addr != "test@example.org" {
-				return smtpd.Error{Code: 502, Message: "Denied"}
+				return &textproto.Error{Code: 502, Msg: "Denied"}
 			}
 			return nil
 		},

--- a/relay.go
+++ b/relay.go
@@ -151,7 +151,7 @@ func (r *relay) authChecker(ctx context.Context, _ smtpd.Peer, username string, 
 			slog.Any("error", err),
 		)
 
-		return observeErr(ctx, smtpd.Error{Code: 535, Message: "Authentication credentials invalid"})
+		return observeErr(ctx, &textproto.Error{Code: 535, Msg: "Authentication credentials invalid"})
 	}
 	return nil
 }
@@ -181,7 +181,7 @@ func (r *relay) connectionChecker(allowedNets []*net.IPNet) func(ctx context.Con
 
 		slog.WarnContext(ctx, "IP out of allowed network range", slog.String("ip", peerIP.String()))
 
-		return observeErr(ctx, smtpd.Error{Code: 421, Message: "Denied - IP out of allowed network range"})
+		return observeErr(ctx, &textproto.Error{Code: 421, Msg: "Denied - IP out of allowed network range"})
 	}
 }
 
@@ -199,12 +199,12 @@ func (r *relay) senderChecker(allowedSender, allowedUsers string) func(ctx conte
 			user, err := AuthFetch(peer.Username)
 			if err != nil {
 				log.WarnContext(ctx, "sender address not allowed", slog.Any("error", err))
-				return observeErr(ctx, smtpd.Error{Code: 451, Message: "sender address not allowed"})
+				return observeErr(ctx, &textproto.Error{Code: 451, Msg: "sender address not allowed"})
 			}
 
 			if !addrAllowed(addr, user.allowedAddresses) {
 				log.WarnContext(ctx, "sender address not allowed")
-				return observeErr(ctx, smtpd.Error{Code: 451, Message: "sender address not allowed"})
+				return observeErr(ctx, &textproto.Error{Code: 451, Msg: "sender address not allowed"})
 			}
 		}
 
@@ -212,7 +212,7 @@ func (r *relay) senderChecker(allowedSender, allowedUsers string) func(ctx conte
 		re, err := regexp.Compile(allowedSender)
 		if err != nil {
 			log.WarnContext(ctx, "allowed_sender invalid", slog.Any("error", err), slog.String("allowed_sender", allowedSender))
-			return observeErr(ctx, smtpd.Error{Code: 451, Message: "sender address not allowed"})
+			return observeErr(ctx, &textproto.Error{Code: 451, Msg: "sender address not allowed"})
 		}
 
 		if re.MatchString(addr) {
@@ -221,7 +221,7 @@ func (r *relay) senderChecker(allowedSender, allowedUsers string) func(ctx conte
 
 		log.WarnContext(ctx, "sender address not allowed")
 
-		return observeErr(ctx, smtpd.Error{Code: 451, Message: "sender address not allowed"})
+		return observeErr(ctx, &textproto.Error{Code: 451, Msg: "sender address not allowed"})
 	}
 }
 
@@ -235,12 +235,12 @@ func (r *relay) recipientChecker(allowed, denied string) func(ctx context.Contex
 			if err != nil {
 				log.WarnContext(ctx, "denied_recipients invalid", slog.String("denied_recipients", denied), slog.Any("error", err))
 
-				return observeErr(ctx, smtpd.Error{Code: 451, Message: "Invalid recipient address"})
+				return observeErr(ctx, &textproto.Error{Code: 451, Msg: "Invalid recipient address"})
 			}
 
 			if deniedRegexp.MatchString(addr) {
 				log.WarnContext(ctx, "receipt address is part of the deny list", slog.String("address", addr))
-				return observeErr(ctx, smtpd.Error{Code: 451, Message: "Denied recipient address"})
+				return observeErr(ctx, &textproto.Error{Code: 451, Msg: "Denied recipient address"})
 			}
 		}
 
@@ -249,7 +249,7 @@ func (r *relay) recipientChecker(allowed, denied string) func(ctx context.Contex
 			allowedRegexp, err := regexp.Compile(allowed)
 			if err != nil {
 				log.WarnContext(ctx, "allowed_recipients invalid", slog.String("allowed_recipients", allowed), slog.Any("error", err))
-				return observeErr(ctx, smtpd.Error{Code: 451, Message: "Invalid recipient address"})
+				return observeErr(ctx, &textproto.Error{Code: 451, Msg: "Invalid recipient address"})
 			}
 
 			if allowedRegexp.MatchString(addr) {
@@ -257,7 +257,7 @@ func (r *relay) recipientChecker(allowed, denied string) func(ctx context.Contex
 			}
 
 			log.WarnContext(ctx, "Invalid recipient address", slog.String("address", addr))
-			return observeErr(ctx, smtpd.Error{Code: 451, Message: "Invalid recipient address"})
+			return observeErr(ctx, &textproto.Error{Code: 451, Msg: "Invalid recipient address"})
 		}
 
 		// No deny nor allow list, receipient check disabled.
@@ -308,7 +308,7 @@ func (r *relay) mailHandler(cfg *config) func(ctx context.Context, peer smtpd.Pe
 			case "plain":
 				auth = smtp.PlainAuth("", cfg.remoteUser, cfg.remotePass, host)
 			default:
-				return observeErr(ctx, smtpd.Error{Code: 530, Message: "Authentication method not supported"})
+				return observeErr(ctx, &textproto.Error{Code: 530, Msg: "Authentication method not supported"})
 			}
 		}
 
@@ -344,23 +344,20 @@ func (r *relay) mailHandler(cfg *config) func(ctx context.Context, peer smtpd.Pe
 		if err != nil {
 			err = fmt.Errorf("sendMail: %w", err)
 
-			var smtpError smtpd.Error
 			var tperr *textproto.Error
 
 			if errors.As(err, &tperr) {
-				smtpError = smtpd.Error{Code: tperr.Code, Message: tperr.Msg}
-
 				logger.ErrorContext(ctx, "delivery failed",
 					slog.Int("err_code", tperr.Code), slog.String("err_msg", tperr.Msg))
 			} else {
-				smtpError = smtpd.Error{Code: 554, Message: "Forwarding failed for message ID " + uniqueID}
+				tperr = &textproto.Error{Code: 554, Msg: "Forwarding failed for message ID " + uniqueID}
 
 				logger.ErrorContext(ctx, "delivery failed", slog.Any("error", err))
 			}
 
-			statusCode = smtpError.Code
+			statusCode = tperr.Code
 
-			return observeErr(ctx, smtpError)
+			return observeErr(ctx, tperr)
 		}
 
 		deliveryLog.InfoContext(ctx, "delivery successful", slog.Int("status_code", statusCode))
@@ -369,7 +366,7 @@ func (r *relay) mailHandler(cfg *config) func(ctx context.Context, peer smtpd.Pe
 	}
 }
 
-func observeErr(ctx context.Context, err smtpd.Error) smtpd.Error {
+func observeErr(ctx context.Context, err *textproto.Error) error {
 	errorsCounter.WithLabelValues(fmt.Sprintf("%v", err.Code)).Inc()
 
 	span := trace.SpanFromContext(ctx)

--- a/relay.go
+++ b/relay.go
@@ -151,7 +151,7 @@ func (r *relay) authChecker(ctx context.Context, _ smtpd.Peer, username string, 
 			slog.Any("error", err),
 		)
 
-		return observeErr(ctx, &textproto.Error{Code: 535, Msg: "Authentication credentials invalid"})
+		return observeErr(ctx, smtpd.ErrAuthInvalid)
 	}
 	return nil
 }
@@ -181,7 +181,7 @@ func (r *relay) connectionChecker(allowedNets []*net.IPNet) func(ctx context.Con
 
 		slog.WarnContext(ctx, "IP out of allowed network range", slog.String("ip", peerIP.String()))
 
-		return observeErr(ctx, &textproto.Error{Code: 421, Msg: "Denied - IP out of allowed network range"})
+		return observeErr(ctx, smtpd.ErrIPDenied)
 	}
 }
 
@@ -199,12 +199,12 @@ func (r *relay) senderChecker(allowedSender, allowedUsers string) func(ctx conte
 			user, err := AuthFetch(peer.Username)
 			if err != nil {
 				log.WarnContext(ctx, "sender address not allowed", slog.Any("error", err))
-				return observeErr(ctx, &textproto.Error{Code: 451, Msg: "sender address not allowed"})
+				return observeErr(ctx, smtpd.ErrSenderDenied)
 			}
 
 			if !addrAllowed(addr, user.allowedAddresses) {
 				log.WarnContext(ctx, "sender address not allowed")
-				return observeErr(ctx, &textproto.Error{Code: 451, Msg: "sender address not allowed"})
+				return observeErr(ctx, smtpd.ErrSenderDenied)
 			}
 		}
 
@@ -212,7 +212,7 @@ func (r *relay) senderChecker(allowedSender, allowedUsers string) func(ctx conte
 		re, err := regexp.Compile(allowedSender)
 		if err != nil {
 			log.WarnContext(ctx, "allowed_sender invalid", slog.Any("error", err), slog.String("allowed_sender", allowedSender))
-			return observeErr(ctx, &textproto.Error{Code: 451, Msg: "sender address not allowed"})
+			return observeErr(ctx, smtpd.ErrSenderDenied)
 		}
 
 		if re.MatchString(addr) {
@@ -221,7 +221,7 @@ func (r *relay) senderChecker(allowedSender, allowedUsers string) func(ctx conte
 
 		log.WarnContext(ctx, "sender address not allowed")
 
-		return observeErr(ctx, &textproto.Error{Code: 451, Msg: "sender address not allowed"})
+		return observeErr(ctx, smtpd.ErrSenderDenied)
 	}
 }
 
@@ -231,16 +231,17 @@ func (r *relay) recipientChecker(allowed, denied string) func(ctx context.Contex
 	return func(ctx context.Context, peer smtpd.Peer, addr string) error {
 		// First, we check the deny list as that one takes precedence.
 		if denied != "" {
+			// TODO: precompile this regexp and reject it at config time
 			deniedRegexp, err := regexp.Compile(denied)
 			if err != nil {
 				log.WarnContext(ctx, "denied_recipients invalid", slog.String("denied_recipients", denied), slog.Any("error", err))
 
-				return observeErr(ctx, &textproto.Error{Code: 451, Msg: "Invalid recipient address"})
+				return observeErr(ctx, smtpd.ErrRecipientInvalid)
 			}
 
 			if deniedRegexp.MatchString(addr) {
 				log.WarnContext(ctx, "receipt address is part of the deny list", slog.String("address", addr))
-				return observeErr(ctx, &textproto.Error{Code: 451, Msg: "Denied recipient address"})
+				return observeErr(ctx, smtpd.ErrRecipientDenied)
 			}
 		}
 
@@ -249,7 +250,7 @@ func (r *relay) recipientChecker(allowed, denied string) func(ctx context.Contex
 			allowedRegexp, err := regexp.Compile(allowed)
 			if err != nil {
 				log.WarnContext(ctx, "allowed_recipients invalid", slog.String("allowed_recipients", allowed), slog.Any("error", err))
-				return observeErr(ctx, &textproto.Error{Code: 451, Msg: "Invalid recipient address"})
+				return observeErr(ctx, smtpd.ErrRecipientInvalid)
 			}
 
 			if allowedRegexp.MatchString(addr) {
@@ -257,7 +258,7 @@ func (r *relay) recipientChecker(allowed, denied string) func(ctx context.Contex
 			}
 
 			log.WarnContext(ctx, "Invalid recipient address", slog.String("address", addr))
-			return observeErr(ctx, &textproto.Error{Code: 451, Msg: "Invalid recipient address"})
+			return observeErr(ctx, smtpd.ErrRecipientInvalid)
 		}
 
 		// No deny nor allow list, receipient check disabled.
@@ -308,7 +309,7 @@ func (r *relay) mailHandler(cfg *config) func(ctx context.Context, peer smtpd.Pe
 			case "plain":
 				auth = smtp.PlainAuth("", cfg.remoteUser, cfg.remotePass, host)
 			default:
-				return observeErr(ctx, &textproto.Error{Code: 530, Msg: "Authentication method not supported"})
+				return observeErr(ctx, smtpd.ErrUnsupportedAuthMethod)
 			}
 		}
 
@@ -350,7 +351,7 @@ func (r *relay) mailHandler(cfg *config) func(ctx context.Context, peer smtpd.Pe
 				logger.ErrorContext(ctx, "delivery failed",
 					slog.Int("err_code", tperr.Code), slog.String("err_msg", tperr.Msg))
 			} else {
-				tperr = &textproto.Error{Code: 554, Msg: "Forwarding failed for message ID " + uniqueID}
+				tperr = smtpd.ErrForwardingFailed
 
 				logger.ErrorContext(ctx, "delivery failed", slog.Any("error", err))
 			}

--- a/relay_test.go
+++ b/relay_test.go
@@ -36,13 +36,13 @@ func Test_RecepientsCheck(t *testing.T) {
 			name:     "with emails not in the allow list",
 			emails:   []string{"delivery@grafana.com"},
 			allowed:  "(.+@example.(org|com)|.+@email.com)",
-			expected: smtpd.Error{Code: 451, Message: "Invalid recipient address"},
+			expected: &textproto.Error{Code: 451, Msg: "Invalid recipient address"},
 		},
 		{
 			name:     "with emails that are denied",
 			emails:   []string{"delivery@example.com", "example@email.com", "<example@email.com>"},
 			denied:   "(.+@example.(org|com)|.+@email.com)",
-			expected: smtpd.Error{Code: 451, Message: "Denied recipient address"},
+			expected: &textproto.Error{Code: 451, Msg: "Denied recipient address"},
 		},
 		{
 			name:   "with valid email that are not denied",
@@ -65,7 +65,7 @@ func Test_RecepientsCheck(t *testing.T) {
 			emails:   []string{"random@deliver.org"},
 			denied:   "(.+@example.(org|com)|.+@email.com)",
 			allowed:  ".+@grafana.com",
-			expected: smtpd.Error{Code: 451, Message: "Invalid recipient address"},
+			expected: &textproto.Error{Code: 451, Msg: "Invalid recipient address"},
 		},
 	}
 

--- a/relay_test.go
+++ b/relay_test.go
@@ -36,13 +36,13 @@ func Test_RecepientsCheck(t *testing.T) {
 			name:     "with emails not in the allow list",
 			emails:   []string{"delivery@grafana.com"},
 			allowed:  "(.+@example.(org|com)|.+@email.com)",
-			expected: &textproto.Error{Code: 451, Msg: "Invalid recipient address"},
+			expected: smtpd.ErrRecipientInvalid,
 		},
 		{
 			name:     "with emails that are denied",
 			emails:   []string{"delivery@example.com", "example@email.com", "<example@email.com>"},
 			denied:   "(.+@example.(org|com)|.+@email.com)",
-			expected: &textproto.Error{Code: 451, Msg: "Denied recipient address"},
+			expected: smtpd.ErrRecipientDenied,
 		},
 		{
 			name:   "with valid email that are not denied",
@@ -65,7 +65,7 @@ func Test_RecepientsCheck(t *testing.T) {
 			emails:   []string{"random@deliver.org"},
 			denied:   "(.+@example.(org|com)|.+@email.com)",
 			allowed:  ".+@grafana.com",
-			expected: &textproto.Error{Code: 451, Msg: "Invalid recipient address"},
+			expected: smtpd.ErrRecipientInvalid,
 		},
 	}
 


### PR DESCRIPTION
There's not really a good reason to have a separate `smtpd.Error` type that duplicates `*textproto.Error`, so this PR changes that. It also simplifies errors with the use of a few sentinels.