### PR TITLE
CodeQL workflow updates

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,18 +24,10 @@ jobs:
         # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v4
       with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
-
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
-
+        go-version-file: go.mod
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3


### PR DESCRIPTION
The CodeQL workflow is warning that the `git checkout HEAD^2` bit is unnecessary now.

Also I'm seeing this warning (though the workflow itself is passing?) - 
<img width="1012" alt="image" src="https://github.com/grafana/smtprelay/assets/2037086/ba864071-1f5b-4ed2-b019-0c06a94e9ef2">

in concept this should fix it 🤷‍♂️ 