### PR TITLE
fix(mod): Fix module path to /v2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version-file: go.mod
       - name: Test
         run: make test
   lint:
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/grafana/smtprelay
+module github.com/grafana/smtprelay/v2
 
-go 1.21
+go 1.22.4
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/integration_test.go
+++ b/integration_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/smtprelay/internal/smtpd"
+	"github.com/grafana/smtprelay/v2/internal/smtpd"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/internal/smtpd/smtpd.go
+++ b/internal/smtpd/smtpd.go
@@ -18,7 +18,7 @@ import (
 	"go.opentelemetry.io/otel"
 )
 
-var tracer = otel.Tracer("github.com/grafana/smtprelay/internal/smtpd")
+var tracer = otel.Tracer("github.com/grafana/smtprelay/v2/internal/smtpd")
 
 // Server defines the parameters for running the SMTP server
 //

--- a/internal/smtpd/smtpd_test.go
+++ b/internal/smtpd/smtpd_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/smtprelay/internal/smtpd"
+	"github.com/grafana/smtprelay/v2/internal/smtpd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/logger.go
+++ b/logger.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/grafana/smtprelay/internal/smtpd"
+	"github.com/grafana/smtprelay/v2/internal/smtpd"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )

--- a/main.go
+++ b/main.go
@@ -11,14 +11,14 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/grafana/smtprelay/internal/smtpd"
-	"github.com/grafana/smtprelay/internal/traceutil"
+	"github.com/grafana/smtprelay/v2/internal/smtpd"
+	"github.com/grafana/smtprelay/v2/internal/traceutil"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/version"
 	"go.opentelemetry.io/otel"
 )
 
-var tracer = otel.Tracer("github.com/grafana/smtprelay")
+var tracer = otel.Tracer("github.com/grafana/smtprelay/v2")
 
 // metrics registry - overridable for tests
 var metricsRegistry = prometheus.DefaultRegisterer

--- a/relay.go
+++ b/relay.go
@@ -14,8 +14,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/grafana/smtprelay/internal/smtpd"
-	"github.com/grafana/smtprelay/internal/traceutil"
+	"github.com/grafana/smtprelay/v2/internal/smtpd"
+	"github.com/grafana/smtprelay/v2/internal/traceutil"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"

--- a/relay_test.go
+++ b/relay_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/grafana/smtprelay/internal/smtpd"
+	"github.com/grafana/smtprelay/v2/internal/smtpd"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
We're at v2.1.0 - the module path ought to end with `/v2`.

This also bumps to Go 1.22.