### PR TITLE
deps(go): Bump supported Go version to 1.23.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,11 +1,6 @@
 linters-settings:
   govet:
     enable-all: true
-  gocyclo:
-    min-complexity: 10
-  gocritic:
-    disabled-checks:
-      - commentFormatting
   dupl:
     threshold: 100
   goconst:
@@ -18,11 +13,6 @@ linters-settings:
     allow-unused: false # report any unused nolint directives
     require-explanation: false # don't require an explanation for nolint directives
     require-specific: false # don't require nolint directives to be specific about which linter is being skipped
-  errcheck:
-    exclude-functions:
-      - io/ioutil.WriteFile
-      - io/ioutil.ReadFile
-      - io.Copy
   gocognit:
     min-complexity: 31
   gomoddirectives:
@@ -43,6 +33,7 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
+    - copyloopvar
     - depguard
     - dupl
     - dupword
@@ -50,7 +41,6 @@ linters:
     - errcheck
     - errname
     - errorlint
-    - exportloopref
     - gocognit
     - goconst
     - gocritic

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/smtprelay/v2
 
-go 1.22.4
+go 1.23.1
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
Also updates the linter config to remove some unnecessary settings and account for a linter that's deprecated with Go 1.23