### PR TITLE
Bugfix AuthFetch: comparing authenticating user to user from `allowed_user` file

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -78,7 +78,7 @@ func AuthFetch(username string) (*AuthUser, error) {
 			continue
 		}
 
-		if strings.EqualFold(username, user.username) {
+		if !strings.EqualFold(username, user.username) {
 			continue
 		}
 

--- a/smtprelay.ini
+++ b/smtprelay.ini
@@ -49,6 +49,7 @@
 ;   username: The SMTP auth username
 ;   bcrypt-hash: The bcrypt hash of the pasword (generate with "./hasher password")
 ;   email: Comma-separated list of allowed "from" addresses:
+;          - Ignored if allowed_sender is not set
 ;          - If omitted, user can send from any address
 ;          - If @domain.com is given, user can send from any address @domain.com
 ;          - Otherwise, email address must match exactly (case-insensitive)


### PR DESCRIPTION
There is a bug in the current `AuthFetch` function: https://github.com/grafana/smtprelay/blob/b43940bc700e178d08e15b5f6ac70e9cf1fd62bd/auth.go#L81

If the username from the sending service matches the username from the allowed_user file, currently `AuthFetch` continues its loop and checks the next line (i.e. checks if the next username matches).  
This should be the other way around:  
If the usernames match, return the `AuthUser` struct, as it is the user trying to authenticate.

The bug was introduced in this commit: https://github.com/grafana/smtprelay/commit/039d54d7719d3ecb1c7399a666ebee27d6919d0c#diff-1f48700829d7e0cdba7f3729d6a7c1c5df3aa11f2aeeed583c7e1e39aa7b66d1L81

Tested in my local environment, it now works as expected.  
(`auth_test.go` does not cover the `AuthFetcher` function.)  

If you are using user authentication with the current version, it was probably warkarounded by sending a wrong username. Then the first line of the allowed_users file will be used for password and email verification.  
What I want to say is: **Ensure to check your allowed_users file and the sending service configuration before you update to this version**  

Additionally, I added a comment to `smtprelay.ini`: If the `allowed_sender` RegEx is not set, the email validation of users from the `allowed_users` file is skipped: https://github.com/grafana/smtprelay/blob/b43940bc700e178d08e15b5f6ac70e9cf1fd62bd/relay.go#L192  
This behavior is fine for me, I just think it's important to be documented.