### PR TITLE
feat: Do not hardcode TLS MinVersion and delegate it to Go version

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -466,7 +466,6 @@ func getServerTLSConfig(certpath, keypath string) (*tls.Config, error) {
 	}
 
 	return &tls.Config{
-		MinVersion:   tls.VersionTLS12,
 		Certificates: []tls.Certificate{cert},
 	}, nil
 }


### PR DESCRIPTION
Alternative approach of:
- https://github.com/grafana/smtprelay/pull/194

With this, we can use the default `GODEBUG` variable to allow old TLS version if needed.
Ref: [Go, Backwards Compatibility, and GODEBUG](https://go.dev/doc/godebug)