### PR TITLE
Add option for client credential flow

### DIFF
--- a/config.go
+++ b/config.go
@@ -50,6 +50,7 @@ type config struct {
 	xoauth2ClientSecret        string
 	xoauth2TokenURL            string
 	xoauth2RefreshToken        string
+	xoauth2Scopes              string
 	allowedNets                []*net.IPNet
 	logHeaders                 map[string]string
 }
@@ -96,8 +97,8 @@ func loadConfig() (*config, error) {
 		}
 	}
 
-	//nolint:nestif
-	if cfg.remoteAuth == "xoauth2" {
+	switch cfg.remoteAuth {
+	case "xoauth2":
 		if cfg.remoteUser == "" {
 			return nil, errors.New("remote_user is required for xoauth2 authentication")
 		}
@@ -107,11 +108,24 @@ func loadConfig() (*config, error) {
 		if cfg.xoauth2ClientSecret == "" {
 			return nil, errors.New("xoauth2_client_secret is required for xoauth2 authentication")
 		}
+		if cfg.xoauth2TokenURL == "" {
+			return nil, errors.New("xoauth2_token_url is required for xoauth2 authentication")
+		}
 		if cfg.xoauth2RefreshToken == "" {
 			return nil, errors.New("xoauth2_refresh_token is required for xoauth2 authentication")
 		}
+	case "xoauth2_client_credentials":
+		if cfg.remoteUser == "" {
+			return nil, errors.New("remote_user is required for xoauth2_client_credentials authentication")
+		}
+		if cfg.xoauth2ClientID == "" {
+			return nil, errors.New("xoauth2_client_id is required for xoauth2_client_credentials authentication")
+		}
+		if cfg.xoauth2ClientSecret == "" {
+			return nil, errors.New("xoauth2_client_secret is required for xoauth2_client_credentials authentication")
+		}
 		if cfg.xoauth2TokenURL == "" {
-			return nil, errors.New("xoauth2_token_url is required for xoauth2 authentication")
+			return nil, errors.New("xoauth2_token_url is required for xoauth2_client_credentials authentication")
 		}
 	}
 
@@ -149,7 +163,7 @@ func registerFlags(f *flag.FlagSet, cfg *config) {
 	f.DurationVar(&cfg.writeTimeout, "write_timeout", 60*time.Second, "Socket timeout for write operations")
 	f.DurationVar(&cfg.dataTimeout, "data_timeout", 5*time.Minute, "Socket timeout for DATA command")
 	f.StringVar(&cfg.remotePass, "remote_pass", "", "Password for authentication on outgoing SMTP server (set $REMOTE_PASS to use env var instead)")
-	f.StringVar(&cfg.remoteAuth, "remote_auth", "plain", "Auth method on outgoing SMTP server (plain, xoauth2)")
+	f.StringVar(&cfg.remoteAuth, "remote_auth", "plain", "Auth method on outgoing SMTP server (plain, xoauth2, xoauth2_client_credentials)")
 	f.StringVar(&cfg.remoteSender, "remote_sender", "", "Sender email address on outgoing SMTP server")
 	f.BoolVar(&cfg.versionInfo, "version", false, "Show version information")
 	f.StringVar(&cfg.logLevel, "log_level", "debug", "Minimum log level to output")
@@ -162,6 +176,7 @@ func registerFlags(f *flag.FlagSet, cfg *config) {
 	f.StringVar(&cfg.xoauth2ClientSecret, "xoauth2_client_secret", "", "Client secret for OAuth2 authentication")
 	f.StringVar(&cfg.xoauth2RefreshToken, "xoauth2_refresh_token", "", "Refresh token for OAuth2 authentication")
 	f.StringVar(&cfg.xoauth2TokenURL, "xoauth2_token_url", "", "OAuth2 token endpoint URL")
+	f.StringVar(&cfg.xoauth2Scopes, "xoauth2_scopes", "", "Space-separated OAuth2 scopes for xoauth2_client_credentials authentication")
 }
 
 // parse the input into a map[string]string. It should be in the form of

--- a/relay.go
+++ b/relay.go
@@ -22,6 +22,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
 )
 
 // relay is an SMTP relay server which can listen on a single address
@@ -68,7 +69,8 @@ func newRelay(ctx context.Context, cfg *config) (*relay, error) {
 		r.rateLimiter = newRateLimiter(cfg.rateLimitMessagesPerSecond, cfg.rateLimitBurst)
 	}
 
-	if cfg.remoteAuth == "xoauth2" {
+	switch cfg.remoteAuth {
+	case "xoauth2":
 		oauth2Config := &oauth2.Config{
 			ClientID:     cfg.xoauth2ClientID,
 			ClientSecret: cfg.xoauth2ClientSecret,
@@ -85,6 +87,18 @@ func newRelay(ctx context.Context, cfg *config) (*relay, error) {
 		r.oauth2TokenSource = oauth2.ReuseTokenSource(
 			initialToken,
 			oauth2Config.TokenSource(ctx, initialToken))
+	case "xoauth2_client_credentials":
+		var scopes []string
+		if cfg.xoauth2Scopes != "" {
+			scopes = splitstr(cfg.xoauth2Scopes, ' ')
+		}
+		ccConfig := &clientcredentials.Config{
+			ClientID:     cfg.xoauth2ClientID,
+			ClientSecret: cfg.xoauth2ClientSecret,
+			TokenURL:     cfg.xoauth2TokenURL,
+			Scopes:       scopes,
+		}
+		r.oauth2TokenSource = oauth2.ReuseTokenSource(nil, ccConfig.TokenSource(ctx))
 	}
 	return r, nil
 }
@@ -367,13 +381,13 @@ func (r *relay) mailHandler(cfg *config) func(ctx context.Context, peer smtpd.Pe
 		host, _, _ := net.SplitHostPort(cfg.remoteHost)
 
 		hasUser := cfg.remoteUser != ""
-		canAuth := hasUser && (cfg.remotePass != "" || cfg.remoteAuth == "xoauth2")
+		canAuth := hasUser && (cfg.remotePass != "" || cfg.remoteAuth == "xoauth2" || cfg.remoteAuth == "xoauth2_client_credentials")
 
 		if canAuth {
 			switch cfg.remoteAuth {
 			case "plain":
 				auth = smtp.PlainAuth("", cfg.remoteUser, cfg.remotePass, host)
-			case "xoauth2":
+			case "xoauth2", "xoauth2_client_credentials":
 				var authToken *oauth2.Token
 
 				authToken, err = r.oauth2TokenSource.Token()

--- a/smtprelay.ini
+++ b/smtprelay.ini
@@ -72,8 +72,22 @@
 ;remote_pass =
 
 ; Authentication method on outgoing SMTP server
-; (plain, xoauth2)
+; (plain, xoauth2, xoauth2_client_credentials)
 ;remote_auth = plain
+
+; Additional settings for remote_auth = xoauth2
+; remote_user is required and must be set to the mailbox address.
+;xoauth2_client_id = your-client-id
+;xoauth2_client_secret = your-client-secret
+;xoauth2_token_url = https://oauth2.example.com/token
+;xoauth2_refresh_token = your-refresh-token
+
+; Additional settings for remote_auth = xoauth2_client_credentials
+; remote_user is required and must be set to the mailbox address.
+;xoauth2_client_id = your-client-id
+;xoauth2_client_secret = your-client-secret
+;xoauth2_token_url = https://oauth2.example.com/token
+;xoauth2_scopes = https://mail.example.com/.default
 
 ; Sender e-mail address on outgoing SMTP server
 ;remote_sender =


### PR DESCRIPTION
## Summary
Add support for the OAuth2 client credentials grant as a distinct `remote_auth` value: `xoauth2_client_credentials`.

The existing xoauth2 auth method (refresh token flow) is unchanged. This adds a parallel option for machine-to-machine scenarios where a delegated user token is unavailable, such as shared mailboxes accessed via service principal in Azure AD / Exchange Online.

## Configuration example (MS 365)

```
remote_auth = xoauth2_client_credentials
remote_user = noreply@example.com
xoauth2_client_id = <client-id>
xoauth2_client_secret = <client-secret>
xoauth2_token_url = https://login.microsoftonline.com/<tenant>/oauth2/v2.0/token
xoauth2_scopes = https://outlook.office365.com/.default
```