### PR TITLE
chore(ci): migrate to docker-build-push-image action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,10 +46,11 @@ jobs:
         with:
           fetch-depth: 1
           persist-credentials: false
-      - uses: grafana/shared-workflows/actions/build-push-to-dockerhub@e7a3275d4c4978a3514801ec55708f1c599a6906 # main
+      - uses: grafana/shared-workflows/actions/docker-build-push-image@21ae57f82e5256e5a418406388926d4ba24bccf2 # docker-build-push-image/v0.3.2
         id: push
         with:
-          repository: grafana/smtprelay
+          dockerhub-repository: grafana/smtprelay
+          registries: dockerhub
           platforms: linux/amd64
           push: "true"
           build-args: |-


### PR DESCRIPTION
Migrates from the deprecated `build-push-to-dockerhub` action to the unified [`docker-build-push-image`](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image) action.

## What This Changes

- Updated action reference from `build-push-to-dockerhub` to `docker-build-push-image@v0.3.2`
- Renamed `repository` input to `dockerhub-repository`
- Added `registries: dockerhub` input

## References

- [docker-build-push-image docs](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image)
- [Migration guide](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image#migrating-from-push-to-gar-docker)
- [Repo migration tracking issue](https://github.com/grafana/deployment_tools/issues/390404)