### PR TITLE
deps: bump go version to 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine@sha256:c2a1f7b2095d046ae14b286b18413a05bb82c9bca9b25fe7ff5efef0f0826166 AS build
+FROM golang:1.26-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS build
 
 RUN apk add --no-cache ca-certificates make git
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/smtprelay/v2
 
-go 1.25.3
+go 1.26.3
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
Bumps Go version to 1.26.3 and updates base image to the latest `golang:1.26.3-alpine`.