### PR TITLE
fix(docker): use passed-in GO_LDFLAGS so release images report clean versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ ENV CGO_ENABLED=0
 COPY go.mod go.sum ./
 RUN go mod download -x
 
+ARG GO_LDFLAGS
+
 COPY . ./
 RUN make build
 # sanity check - make sure the binary runs and is executable


### PR DESCRIPTION
Every tagged build was getting built with an X.Y.Z-dirty version, because the `GO_LDFLAGS` var wasn't being passed through. This should fix it.